### PR TITLE
No Alt-Ctrl-Shift for arrow navigation

### DIFF
--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -52,10 +52,12 @@ $.magnificPopup.registerModule('gallery', {
 				}
 
 				_document.on('keydown'+ns, function(e) {
-					if (e.keyCode === 37) {
-						mfp.prev();
-					} else if (e.keyCode === 39) {
-						mfp.next();
+					if (!e.altKey && !e.ctrlKey && !e.shiftKey) {
+						if (e.keyCode === 37) {
+							mfp.prev();
+						} else if (e.keyCode === 39) {
+							mfp.next();
+						}
 					}
 				});
 			});


### PR DESCRIPTION
Only react on left and right keyboard arrow keys when there is no Alt or Ctrl or Shift key pressed.  Otherwise it breaks back button navigation in browser.