### PR TITLE
Fix close event handling (#362)

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -213,15 +213,20 @@ MagnificPopup.prototype = {
 			});
 
 			mfp.wrap = _getEl('wrap').attr('tabindex', -1).on('click'+EVENT_NS, function(e) {
-				if(mfp._checkIfClose(e.target)) {
+				if(mfp._checkIfClose(e.target, e.target._mfpFromContent)) {
 					mfp.close();
 				}
+				delete e.target._mfpFromContent;
 			});
 
 			mfp.container = _getEl('container', mfp.wrap);
 		}
 
 		mfp.contentContainer = _getEl('content');
+		mfp.contentContainer.on('click'+EVENT_NS, function(e) {
+			// Notify wrap click event handler the event bubbled from content
+			e.target._mfpFromContent = (e.target !== this);
+		});
 		if(mfp.st.preloader) {
 			mfp.preloader = _getEl('preloader', mfp.container, mfp.st.tLoading);
 		}
@@ -705,8 +710,7 @@ MagnificPopup.prototype = {
 	 */
 	// Check to close popup or not
 	// "target" is an element that was clicked
-	_checkIfClose: function(target) {
-
+	_checkIfClose: function(target, fromContent) {
 		if($(target).hasClass(PREVENT_CLOSE_CLASS)) {
 			return;
 		}
@@ -717,14 +721,11 @@ MagnificPopup.prototype = {
 		if(closeOnContent && closeOnBg) {
 			return true;
 		} else {
-
-			// We close the popup if click is on close button or on preloader. Or if there is no content.
-			if(!mfp.content || $(target).hasClass('mfp-close') || (mfp.preloader && target === mfp.preloader[0]) ) {
+			// We close the popup if click is on close button or on preloader.
+			if($(target).hasClass('mfp-close') || (mfp.preloader && target === mfp.preloader[0]) ) {
 				return true;
 			}
-
-			// if click is outside the content
-			if(  (target !== mfp.content[0] && !$.contains(mfp.content[0], target))  ) {
+			if(!fromContent) {
 				if(closeOnBg) {
 					// last check, if the clicked element is in DOM, (in case it's removed onclick)
 					if( $.contains(document, target) ) {


### PR DESCRIPTION
The way mfp._checkIfClose checks if target is in content is not reliable, because the event may have been handled before it bubbled to mfp.wrap, causing such changes to DOM that the target is no longer in content.

This fix adds a click event handler to mfp.contentContainer which sets an indicator that the event came from content. This indicator is passed to mfp._checkIfClose, which uses it instead of the original $.contains check. The indicator cannot be set on the event object itself, as it is not preserved by jQuery while bubbling. It is set on the target instead and removed in the mfp.wrap click event handler.

The fix is somewhat dirty, so it may not be considered suitable for merging, but it works with the example outlined in the issue report (#362), and with the examples on the demo page.