### PR TITLE
Fix multiple focus issues (#426)

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -750,11 +750,18 @@ MagnificPopup.prototype = {
 		return (  (mfp.isIE7 ? _document.height() : document.body.scrollHeight) > (winHeight || _window.height()) );
 	},
 	_setFocus: function() {
-		(mfp.st.focus ? mfp.content.find(mfp.st.focus).eq(0) : mfp.wrap).focus();
+		if(mfp.st.focus) {
+			var el = mfp.content.find(mfp.st.focus).eq(0);
+			if(el.length) {
+				el.focus();
+				return;
+			}
+		}
+		mfp.wrap.focus();
 	},
 	_onFocusIn: function(e) {
 		if( e.target !== mfp.wrap[0] && !$.contains(mfp.wrap[0], e.target) ) {
-			mfp._setFocus();
+			mfp.wrap.focus();
 			return false;
 		}
 	},


### PR DESCRIPTION
* Handle well the situation when mfp.st.focus is set to a non-existing element (set focus to mfp.wrap instead).

* Fix focus wrapping when mfp.st.focus is set. Focus now wraps to mfp.wrap instead to mfp.st.focus, which may not not be at the top of the popup, effectively hiding focusable elements above it from tab navigation.